### PR TITLE
Feat/#24 color palette init

### DIFF
--- a/DreamEgg/DreamEgg.xcodeproj/project.pbxproj
+++ b/DreamEgg/DreamEgg.xcodeproj/project.pbxproj
@@ -17,11 +17,11 @@
 		7E29DE6A2A5BCE3E00718C17 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E29DE692A5BCE3E00718C17 /* Preview Assets.xcassets */; };
 		7EA424252A5D32E900D0709B /* DailySleepTimeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA424242A5D32E900D0709B /* DailySleepTimeStore.swift */; };
 		7EA424282A5D382700D0709B /* DreamEgg.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 7EA424262A5D382700D0709B /* DreamEgg.xcdatamodeld */; };
-		7E29DE6F2A5BCE3E00718C17 /* DreamEgg.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 7E29DE6D2A5BCE3E00718C17 /* DreamEgg.xcdatamodeld */; };
-		AE30B5CA2A5E8EA100F9250C /* LocalNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE30B5C92A5E8EA100F9250C /* LocalNotificationStore.swift */; };
-		AEE9E2F32A5BE9BD00D24A71 /* LocalNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE9E2F22A5BE9BD00D24A71 /* LocalNotificationView.swift */; };
+		7EE3F5472A61269300764E86 /* Color+Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE3F5462A61269300764E86 /* Color+Palette.swift */; };
 		93ADAC822A5C2CE1000E27AD /* MapViewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93ADAC812A5C2CE1000E27AD /* MapViewStore.swift */; };
 		93AF35562A5EBC8F000063ED /* MapTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AF35552A5EBC8F000063ED /* MapTestView.swift */; };
+		AE30B5CA2A5E8EA100F9250C /* LocalNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE30B5C92A5E8EA100F9250C /* LocalNotificationStore.swift */; };
+		AEE9E2F32A5BE9BD00D24A71 /* LocalNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE9E2F22A5BE9BD00D24A71 /* LocalNotificationView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,11 +36,11 @@
 		7E29DE692A5BCE3E00718C17 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		7EA424242A5D32E900D0709B /* DailySleepTimeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailySleepTimeStore.swift; sourceTree = "<group>"; };
 		7EA424272A5D382700D0709B /* DreamEgg.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DreamEgg.xcdatamodel; sourceTree = "<group>"; };
-		7E29DE6E2A5BCE3E00718C17 /* DreamEgg.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DreamEgg.xcdatamodel; sourceTree = "<group>"; };
-		AE30B5C92A5E8EA100F9250C /* LocalNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationStore.swift; sourceTree = "<group>"; };
-		AEE9E2F22A5BE9BD00D24A71 /* LocalNotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationView.swift; sourceTree = "<group>"; };
+		7EE3F5462A61269300764E86 /* Color+Palette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Palette.swift"; sourceTree = "<group>"; };
 		93ADAC812A5C2CE1000E27AD /* MapViewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewStore.swift; sourceTree = "<group>"; };
 		93AF35552A5EBC8F000063ED /* MapTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTestView.swift; sourceTree = "<group>"; };
+		AE30B5C92A5E8EA100F9250C /* LocalNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationStore.swift; sourceTree = "<group>"; };
+		AEE9E2F22A5BE9BD00D24A71 /* LocalNotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,7 +71,6 @@
 				7E1B06BD2A5BE6E00072ED3F /* ContentViewStore.swift */,
 				7E1B06CD2A5BF5C20072ED3F /* CoreDataStore.swift */,
 				7EA424242A5D32E900D0709B /* DailySleepTimeStore.swift */,
-				AEE9E2F22A5BE9BD00D24A71 /* LocalNotificationView.swift */,
 				AE30B5C92A5E8EA100F9250C /* LocalNotificationStore.swift */,
 				93ADAC812A5C2CE1000E27AD /* MapViewStore.swift */,
 			);
@@ -114,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				7E29DE622A5BCE3D00718C17 /* DreamEggApp.swift */,
+				7EE3F5452A61268A00764E86 /* Extensions */,
 				7E1B06BF2A5BE6E90072ED3F /* Models */,
 				7E1B06BC2A5BE6D20072ED3F /* Stores */,
 				7E1B06BB2A5BE6CD0072ED3F /* Views */,
@@ -130,6 +130,14 @@
 				7E29DE692A5BCE3E00718C17 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		7EE3F5452A61268A00764E86 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				7EE3F5462A61269300764E86 /* Color+Palette.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -214,11 +222,12 @@
 				7E1B06C12A5BE6F40072ED3F /* CoreDataContainer.swift in Sources */,
 				7E29DE632A5BCE3D00718C17 /* DreamEggApp.swift in Sources */,
 				7E1B06C12A5BE6F40072ED3F /* CoreDataContainer.swift in Sources */,
+				7EE3F5472A61269300764E86 /* Color+Palette.swift in Sources */,
 				AEE9E2F32A5BE9BD00D24A71 /* LocalNotificationView.swift in Sources */,
 				AE30B5CA2A5E8EA100F9250C /* LocalNotificationStore.swift in Sources */,
 				7E29DE632A5BCE3D00718C17 /* DreamEggApp.swift in Sources */,
 				93AF35562A5EBC8F000063ED /* MapTestView.swift in Sources */,
-				7E1B06C12A5BE6F40072ED3F /* UserSleepTime.swift in Sources */,
+				7E1B06C12A5BE6F40072ED3F /* CoreDataContainer.swift in Sources */,
 				93ADAC822A5C2CE1000E27AD /* MapViewStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -348,7 +357,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"DreamEgg/Preview Content\"";
-				DEVELOPMENT_TEAM = HFR7W36699;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -378,7 +386,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"DreamEgg/Preview Content\"";
-				DEVELOPMENT_TEAM = HFR7W36699;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/DreamEgg/DreamEgg/Extensions/Color+Palette.swift
+++ b/DreamEgg/DreamEgg/Extensions/Color+Palette.swift
@@ -1,8 +1,99 @@
 //
-//  Color+.swift
+//  Color+Palette.swift
 //  DreamEgg
 //
 //  Created by Celan on 2023/07/14.
 //
 
-import Foundation
+import SwiftUI
+
+extension Color {
+    // MARK: Hex Init
+    init(hex: Int, opacity: Double = 1.0) {
+        let red = Double((hex >> 16) & 0xff) / 255
+        let green = Double((hex >> 8) & 0xff) / 255
+        let blue = Double((hex >> 0) & 0xff) / 255
+        
+        self.init(.sRGB, red: red, green: green, blue: blue, opacity: opacity)
+    }
+    
+    init(hex: String) {
+        let scanner = Scanner(string: hex)
+        _ = scanner.scanString("#")
+        
+        var rgb: UInt64 = 0
+        scanner.scanHexInt64(&rgb)
+        
+        let r = Double((rgb >> 16) & 0xFF) / 255.0
+        let g = Double((rgb >>  8) & 0xFF) / 255.0
+        let b = Double((rgb >>  0) & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+extension Color {
+    // MARK: Gradients
+    static var dreamPurple: Self {
+        .init(hex: "#A092C8")
+    }
+    
+    static var eggViolet: Self {
+        .init(hex: "#7785D0")
+    }
+    
+    static var dreamSky: Self {
+        .init(hex: "#A3CDFF")
+    }
+    
+    static var eggYellow: Self {
+        .init(hex: "#FFCB45")
+    }
+    
+    // MARK: Buttons
+    static var primaryButtonYellow: Self {
+        .init(hex: "#F7D25C")
+    }
+    
+    static var primaryButtonBrown: Self {
+        .init(hex: "#8A6F30")
+    }
+    
+    static var subButtonSky: Self {
+        .init(hex: "#E7EEFE")
+    }
+    
+    static var subButtonBlue: Self {
+        .init(hex: "#639BFF")
+    }
+}
+
+// MARK: Preview
+struct Color_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            LinearGradient(
+                colors: [
+                .dreamPurple,
+                .eggViolet
+            ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            
+            LinearGradient(
+                colors: [
+                .dreamSky,
+                .eggYellow
+            ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            
+            Color.primaryButtonBrown
+            Color.primaryButtonYellow
+            
+            Color.subButtonSky
+            Color.subButtonBlue
+        }
+    }
+}

--- a/DreamEgg/DreamEgg/Extensions/Color+Palette.swift
+++ b/DreamEgg/DreamEgg/Extensions/Color+Palette.swift
@@ -1,0 +1,8 @@
+//
+//  Color+.swift
+//  DreamEgg
+//
+//  Created by Celan on 2023/07/14.
+//
+
+import Foundation


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

- 작업 이슈: #24 
- Figma Design System을 참고하여 Color+Palette를 구현했습니다.
  - [Figma Color Design System](https://www.figma.com/file/BPFzKg5y8RO75msmI4Gshe/K-Jammy?type=design&node-id=292-18677&mode=design&t=KWLtBt2oMnhqUogj-4)

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

1. Color hex Initializer
  - Hex 코드를 받아서 Color로 그려주는 생성자 구현
2. Figma에 정의된 컬러 8개 구현
3. Preview 구현

## `Color(hex:String)`
<!-- 작업 내용 1 -->
```swift
// 문자열로 Hex 코드를 입력하면 RGB 코드로 변환된 컬러를 리턴합니다.
init(hex: String) {
    let scanner = Scanner(string: hex)
    _ = scanner.scanString("#")
    
    var rgb: UInt64 = 0
    scanner.scanHexInt64(&rgb)
    
    let r = Double((rgb >> 16) & 0xFF) / 255.0
    let g = Double((rgb >>  8) & 0xFF) / 255.0
    let b = Double((rgb >>  0) & 0xFF) / 255.0
    self.init(red: r, green: g, blue: b)
}
```

## Example
```swift
// Color+
static var dreamPurple: Self {
    .init(hex: "#A092C8")
}

// 호출
Color.dreamPurple
```

## 작업 결과(이미지 첨부는 선택)
| Gradient와 8색 |
|:--------:|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-14 at 16 02 58](https://github.com/DeveloperAcademy-POSTECH/MC3-G5T15-DreamEgg/assets/82270058/dde1b634-183d-49cd-9755-f0b5527583b4) | 
