### PR TITLE
[Feat/#55] Add Haptic feedback for Egg gesture

### DIFF
--- a/DreamEgg/DreamEgg/Stores/EggAnimationStore.swift
+++ b/DreamEgg/DreamEgg/Stores/EggAnimationStore.swift
@@ -1,5 +1,5 @@
 //
-//  EggInteractionStore.swift
+//  EggAnimationStore.swift
 //  DreamEgg
 //
 //  Created by Sebin Kwon on 2023/07/13.
@@ -22,6 +22,7 @@ class EggAnimation: ObservableObject {
             .onChanged { value in
                 if !self.isLongPress {
                     self.isLongPress = true
+                    self.eggHeartBeat()
                 }
                 let dragAngle = Angle(radians: Double(value.translation.width) * 0.01)
                 let newRotationAngle = Angle.degrees(10.0) + dragAngle
@@ -30,6 +31,22 @@ class EggAnimation: ObservableObject {
             .onEnded { value in
                 self.isLongPress = false
                 self.direction = self.rotationAngle.degrees >= 0 ? -1 : 1
+                let velocity = CGSize(
+                        width:  value.predictedEndLocation.x - value.location.x,
+                        height: value.predictedEndLocation.y - value.location.y
+                    )
+                switch abs(velocity.width) {
+                case 0..<60:
+                    HapticManager.instance.selection()
+                case 61..<90:
+                    HapticManager.instance.impact(style: .soft)
+                case 91..<120:
+                    HapticManager.instance.impact(style: .light)
+                case 121..<150:
+                    HapticManager.instance.impact(style: .medium)
+                default:
+                    HapticManager.instance.notification(type: .error)
+                }
                 if !self.isAnimationRunning {
                     self.startPendulumAnimation()
                 }
@@ -46,6 +63,15 @@ class EggAnimation: ObservableObject {
                 self.startPendulumAnimation()
             } else {
                 self.isAnimationRunning = false
+            }
+        }
+    }
+    
+    private func eggHeartBeat() {
+        HapticManager.instance.impact(style: .soft)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            if self.isLongPress {
+                self.eggHeartBeat()
             }
         }
     }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- 알 드래그 시 햅틱 피드백을 구현했습니다.
- 작업 이슈: #55 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- 드래그 중 심장박동 햅틱 구현
- 드래그 끝나는 시점의 속도에 따라서 다양한 햅틱 구현

## `Logic1`
<!-- 작업 내용 1 -->
### 드래그 끝나는 시점의 속도에 따른 햅틱 분기처리
```swift
let velocity = CGSize(
    width:  value.predictedEndLocation.x - value.location.x,
    height: value.predictedEndLocation.y - value.location.y
)
switch abs(velocity.width) {
case 0..<60:
    HapticManager.instance.selection()
case 61..<90:
    HapticManager.instance.impact(style: .soft)
case 91..<120:
    HapticManager.instance.impact(style: .light)
case 121..<150:
    HapticManager.instance.impact(style: .medium)
default:
    HapticManager.instance.notification(type: .error)
}
```
### 심장박동을 구현한 함수
```swift
private func eggHeartBeat() {
    HapticManager.instance.impact(style: .soft)
    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
        if self.isLongPress {
            self.eggHeartBeat()
        }
    }
}
```