### PR TITLE
Feat/#53-Connecting-Logic-to-LofiDreamWorldView

### DIFF
--- a/DreamEgg/DreamEgg/Stores/MapViewStore.swift
+++ b/DreamEgg/DreamEgg/Stores/MapViewStore.swift
@@ -12,7 +12,10 @@ final class MapViewStore : ObservableObject {
     let mapWidth = UIScreen.main.bounds.width * 0.8
     let mapHeight = UIScreen.main.bounds.height * 0.7
     let objSize : CGFloat = 50
-    let timers = [Timer.publish(every: 3, on: .main, in: .common).autoconnect(), Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()]
+    let timers = [
+        Timer.publish(every: 3.0, on: .main, in: .common).autoconnect(),
+        Timer.publish(every: 0.5, on: .main, in: .common).autoconnect(),
+    ]
     var num : Int = 0
     @ObservedObject var dailySleepTimeStore = DailySleepTimeStore()
     @Published var positions = [CGPoint]()
@@ -75,7 +78,6 @@ final class MapViewStore : ObservableObject {
         
         for i in 0 ..< num {
             n = 0
-            
             while true {
                 isDuplicated = false
                 j = 0

--- a/DreamEgg/DreamEgg/Stores/MapViewStore.swift
+++ b/DreamEgg/DreamEgg/Stores/MapViewStore.swift
@@ -11,31 +11,31 @@ import SwiftUI
 class MapViewStore : ObservableObject {
     let mapWidth = UIScreen.main.bounds.width * 0.8
     let mapHeight = UIScreen.main.bounds.height * 0.7
-    let objSize : CGFloat = 70
-    let timers = [Timer.publish(every: 1.5, on: .main, in: .common).autoconnect(), Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()]
-    var num  = 0
+    let objSize : CGFloat = 50
+    let timers = [Timer.publish(every: 3, on: .main, in: .common).autoconnect(), Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()]
+    var num = 0
+    @ObservedObject var dailySleepTimeStore = DailySleepTimeStore()
     @Published var positions = [CGPoint]()
     @Published var names = [[String]]()
     
     init() {
-        self.num = getNumFromCoreData() // CoreData 구현 코드와 병합 후 구현 예정입니다.
-        getNamesFromCoreData() // CoreData 구현 코드와 병합 후 구현 예정입니다.
+        self.num = dailySleepTimeStore.dailySleepDict.count
+        getNamesFromCoreData()
         GeneratePosRandomly()
     }
     
-    func getNumFromCoreData() -> Int { // CoreData에서 객체들의 데이터를 받아와, 객체들의 갯수를 저장합니다.
-        return 5 // 시연을 위해 임의로 설정해두었습니다.
-    }
-    
-    func getNamesFromCoreData() { // 코어 데이터에서 객체들의 데이터를 받아와, 객체들의 이름을 저장합니다.
-        for _ in 0 ..< num { // 시연을 위해 임의로 객체들의 이름을 넣어두었습니다.
-            names.append(["beenzino","BreathIn"])
+    /// CoreData에서 객체들의 데이터를 받아와 객체들의 이름을 저장합니다.
+    func getNamesFromCoreData() {
+        for element in dailySleepTimeStore.dailySleepDict {
+            names.append([element.value.animalName ?? "" ,"_a"])
         }
     }
     
-    func GeneratePosRandomly() { // 객체들의 초기 위치를 지도 크기 내에서 객체들이 서로 겹치지 않게 랜덤하게 설정합니다.
+    
+    /// 드림펫들의 초기 위치를 지도 크기 내에서 서로 겹치지 않게 랜덤하게 설정합니다.
+    func GeneratePosRandomly() {
         let xPosBoundary = mapWidth - objSize * 2
-        let yPosBoundary = mapHeight - objSize * 2
+        let yPosBoundary = mapHeight * 0.15 - objSize / 2
         var xPosTemp: CGFloat
         var yPosTemp: CGFloat
         var isDuplicated : Bool
@@ -46,7 +46,7 @@ class MapViewStore : ObservableObject {
                 isDuplicated = false
                 j = 0
                 xPosTemp = CGFloat(arc4random_uniform(UInt32(xPosBoundary))) + objSize
-                yPosTemp = CGFloat(arc4random_uniform(UInt32(yPosBoundary))) + objSize
+                yPosTemp = CGFloat(arc4random_uniform(UInt32(yPosBoundary))) + mapHeight * 0.85
 
                 while j < i {
                     if pow(self.positions[j].x - xPosTemp, 2) + pow(self.positions[j].y - yPosTemp, 2) <= pow(objSize,2) {
@@ -64,13 +64,18 @@ class MapViewStore : ObservableObject {
         }
     }
     
-    func changePosition() { // 객체들의 위치를 랜덤하게 변경합니다. 변경 시에도 지도 크기내에서 객체들이 서로 겹치지 않게 변경합니다.
+    
+    /// 드림펫들의 위치를 지도 크기 내에서 서로 겹치지 않도록 랜덤하게 변경합니다.
+    func changePosition() {
         var newXPos: CGFloat
         var newYPos: CGFloat
         var isDuplicated : Bool
         var j : Int
-
+        var n : Int
+        
         for i in 0 ..< num {
+            n = 0
+            
             while true {
                 isDuplicated = false
                 j = 0
@@ -78,12 +83,13 @@ class MapViewStore : ObservableObject {
                 newYPos = positions[i].y + CGFloat(arc4random_uniform(UInt32(100))) - 50
 
                 // map boundary check
-                if newXPos < objSize / 2 || newYPos < objSize / 2 || newXPos > mapWidth - objSize / 2 || newYPos > mapHeight - objSize / 2 {
+                if newXPos < objSize || newYPos < mapHeight * 0.85 || newXPos > mapWidth - objSize || newYPos > mapHeight - objSize / 2 {
+                    n += 1
                     continue
                 }
                 
                 // object duplication check
-                while j < i {
+                while n < 100 && j < i {
                     if pow(newXPos - positions[j].x , 2) + pow(newYPos - positions[j].y , 2) <= pow(objSize,2) {
                         isDuplicated = true
                         break
@@ -100,13 +106,15 @@ class MapViewStore : ObservableObject {
         }
     }
     
-    func changeImage() { // 호흡 애니메이션 구현을 위해 이미지의 이름을 변경합니다.
+    
+    /// 이미지의 이름을 변경을 통해 드림펫들의 애니메이션을 구현합니다.
+    func changeImage() {
         for i in 0 ..< num {
-            if names[i][1] == "BreathIn" {
-                names[i][1] = "BreathOut"
+            if names[i][1] == "_a" {
+                names[i][1] = "_b"
             }
             else {
-                names[i][1] = "BreathIn"
+                names[i][1] = "_a"
             }
         }
     }

--- a/DreamEgg/DreamEgg/Stores/MapViewStore.swift
+++ b/DreamEgg/DreamEgg/Stores/MapViewStore.swift
@@ -8,12 +8,12 @@
 import Foundation
 import SwiftUI
 
-class MapViewStore : ObservableObject {
+final class MapViewStore : ObservableObject {
     let mapWidth = UIScreen.main.bounds.width * 0.8
     let mapHeight = UIScreen.main.bounds.height * 0.7
     let objSize : CGFloat = 50
     let timers = [Timer.publish(every: 3, on: .main, in: .common).autoconnect(), Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()]
-    var num = 0
+    var num : Int = 0
     @ObservedObject var dailySleepTimeStore = DailySleepTimeStore()
     @Published var positions = [CGPoint]()
     @Published var names = [[String]]()

--- a/DreamEgg/DreamEgg/Views/Lofi/LofiDreamWorldView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiDreamWorldView.swift
@@ -28,7 +28,7 @@ struct LofiDreamWorldView: View {
                     .aspectRatio(contentMode: .fit)
                     .padding()
 
-                ForEach((0...mapViewStore.num - 1), id: \.self) { i in
+                ForEach((0 ..< mapViewStore.num), id: \.self) { i in
                     Button(action:{
 
                     }) {

--- a/DreamEgg/DreamEgg/Views/Lofi/LofiDreamWorldView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiDreamWorldView.swift
@@ -8,20 +8,44 @@
 import SwiftUI
 
 struct LofiDreamWorldView: View {
+    @ObservedObject var mapViewStore = MapViewStore()
+
+
     var body: some View {
         VStack {
             DETitleHeader(title: "Dream World")
-            
+
             Spacer()
                 .frame(maxHeight: 24)
-            
-            Image("DreamWorldMap")
-                .resizable()
-                .frame(
-                    maxHeight: .infinity
-                )
-                .aspectRatio(contentMode: .fit)
-                .padding()
+
+            ZStack {
+                Image("DreamWorldMap")
+                    .resizable()
+                    .frame(
+                        width: mapViewStore.mapWidth,
+                        height: mapViewStore.mapHeight
+                    )
+                    .aspectRatio(contentMode: .fit)
+                    .padding()
+
+                ForEach((0...mapViewStore.num - 1), id: \.self) { i in
+                    Button(action:{
+
+                    }) {
+                        Image("\(mapViewStore.names[i][0])"+"\(mapViewStore.names[i][1])")
+                    }
+                    .position(mapViewStore.positions[i])
+                }
+            }
+            .frame(width: mapViewStore.mapWidth, height: mapViewStore.mapHeight)
+            .onReceive(mapViewStore.timers[0]) { _ in
+                withAnimation {
+                    mapViewStore.changePosition()
+                }
+            }
+            .onReceive(mapViewStore.timers[1]) { _ in
+                mapViewStore.changeImage()
+            }
         }
         .frame(
             maxHeight: .infinity

--- a/DreamEgg/DreamEgg/Views/Lofi/LofiDreamWorldView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiDreamWorldView.swift
@@ -38,11 +38,11 @@ struct LofiDreamWorldView: View {
                 }
             }
             .frame(width: mapViewStore.mapWidth, height: mapViewStore.mapHeight)
-            .onReceive(mapViewStore.timers[0]) { _ in
-                withAnimation {
-                    mapViewStore.changePosition()
-                }
-            }
+//            .onReceive(mapViewStore.timers[0]) { _ in
+//                withAnimation {
+//                    mapViewStore.changePosition()
+//                }
+//            }
             .onReceive(mapViewStore.timers[1]) { _ in
                 mapViewStore.changeImage()
             }
@@ -56,7 +56,7 @@ struct LofiDreamWorldView: View {
 
 struct LofiDreamWorldView_Previews: PreviewProvider {
     static var previews: some View {
-//        LofiDreamWorldView()
-        LofiMainTabView()
+        LofiDreamWorldView()
+//        LofiMainTabView()
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- User Test를 위해 기존의 MapView에 존재하던 Logic을 LofiDreamWorldView에 이식하였습니다.
- 작업 이슈: #53 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- LofiDreamWorldView로 MapView 로직 이식
    - 기존의 더미 데이터를 Core Data로 변환
- 새롭게 정의된 맵 내 이동 가능 구역에 맞게 이동 애니메이션 로직 개선

## `Logic1`
<!-- 작업 내용 1 -->
```swift
final class MapViewStore : ObservableObject {
    let mapWidth = UIScreen.main.bounds.width * 0.8
    let mapHeight = UIScreen.main.bounds.height * 0.7
    let objSize : CGFloat = 50
    let timers = [Timer.publish(every: 3, on: .main, in: .common).autoconnect(), Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()]
    var num : Int = 0
    @ObservedObject var dailySleepTimeStore = DailySleepTimeStore()
    @Published var positions = [CGPoint]()
    @Published var names = [[String]]()
    
    init() {
        self.num = dailySleepTimeStore.dailySleepDict.count
        getNamesFromCoreData()
        GeneratePosRandomly()
    }
    
    /// CoreData에서 객체들의 데이터를 받아와 객체들의 이름을 저장합니다.
    func getNamesFromCoreData() {
        for element in dailySleepTimeStore.dailySleepDict {
            names.append([element.value.animalName ?? "" ,"_a"])
        }
    }
```
기존에 존재하던 더미데이터들을 삭제하고 Core Data로부터 가져온 데이터로 대체하였습니다.

```swift
 func changePosition() {
        var newXPos: CGFloat
        var newYPos: CGFloat
        var isDuplicated : Bool
        var j : Int
        var n : Int
        
        for i in 0 ..< num {
            n = 0
            
            while true {
                isDuplicated = false
                j = 0
                newXPos = positions[i].x + CGFloat(arc4random_uniform(UInt32(100))) - 50
                newYPos = positions[i].y + CGFloat(arc4random_uniform(UInt32(100))) - 50

                // map boundary check
                if newXPos < objSize || newYPos < mapHeight * 0.85 || newXPos > mapWidth - objSize || newYPos > mapHeight - objSize / 2 {
                    n += 1
                    continue
                }
                
                // object duplication check
                while n < 100 && j < i {
                    if pow(newXPos - positions[j].x , 2) + pow(newYPos - positions[j].y , 2) <= pow(objSize,2) {
                        isDuplicated = true
                        break
                    }
                    j += 1
                }

                if isDuplicated == false {
                    positions[i].x = newXPos
                    positions[i].y = newYPos
                    break
                }
            }
        }
    }
```
기존의 이동 가능 구역은 맵 전체 였지만, 아래 잔디 영역으로 제한 되었기 때문에 로직을 변경하였습니다. 가로 340, 세로 120의 영역에 가로,세로 50의 정사각형 최대 6개가 들어가는 경우, 서로가 겹치지 않게 이동하기 위해서 너무 많은 연산을 필요로 하기 때문에 각각의 난수 발생 시 100번 이상일 경우, 정사각형의 중복을 고려하지 않는 방향으로 구현하였습니다. 진행될 UT 에서는 드림펫의 개수가 1개 이므로 문제가 되지 않지만, 이후에 각각의 드림펫들이 겹치는 것을 아예 배제 하기 위해서는 새로운 로직이 필요할 듯 합니다.

 ## 작업 결과(이미지 첨부는 선택)
작업 결과는 아니지만, 이후에 드림펫 에셋을 넣어주실 때, "dreampet_a"와 "dreampet_b"로 넣어주시면 감사하겠습니다.
@ValseLee @SeBin-Kwon @Gxxunx @pscu91 
