### PR TITLE
[Feat/#76] LofiFailedView 작업

### DIFF
--- a/DreamEgg/DreamEgg.xcodeproj/project.pbxproj
+++ b/DreamEgg/DreamEgg.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		93E97B392A6FA56B0000DB2B /* LofiBirthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E97B382A6FA56B0000DB2B /* LofiBirthView.swift */; };
 		AE05EE112A6E634A0006F40D /* LofiEggDrawView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE05EE102A6E634A0006F40D /* LofiEggDrawView.swift */; };
 		AE05EE132A6E65D30006F40D /* LofiEggInteractionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE05EE122A6E65D30006F40D /* LofiEggInteractionView.swift */; };
+		C28B7C892A724BC60009BECE /* LofiFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28B7C882A724BC60009BECE /* LofiFailedView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -136,6 +137,7 @@
 		93E97B382A6FA56B0000DB2B /* LofiBirthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LofiBirthView.swift; sourceTree = "<group>"; };
 		AE05EE102A6E634A0006F40D /* LofiEggDrawView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LofiEggDrawView.swift; sourceTree = "<group>"; };
 		AE05EE122A6E65D30006F40D /* LofiEggInteractionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LofiEggInteractionView.swift; sourceTree = "<group>"; };
+		C28B7C882A724BC60009BECE /* LofiFailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LofiFailedView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -288,6 +290,7 @@
 				7EE701E52A6E4C7E00DEEFA6 /* LofiDreamWorldView.swift */,
 				7EE701E62A6E4C7E00DEEFA6 /* LofiMainEggView.swift */,
 				93E97B382A6FA56B0000DB2B /* LofiBirthView.swift */,
+				C28B7C882A724BC60009BECE /* LofiFailedView.swift */,
 				AE05EE102A6E634A0006F40D /* LofiEggDrawView.swift */,
 				AE05EE122A6E65D30006F40D /* LofiEggInteractionView.swift */,
 			);
@@ -422,6 +425,7 @@
 				7EE7022B2A6E4C7E00DEEFA6 /* TimePickerView.swift in Sources */,
 				7EE7021D2A6E4C7E00DEEFA6 /* LofiDreamWorldView.swift in Sources */,
 				7EE7022D2A6E4C7E00DEEFA6 /* DETitleHeader.swift in Sources */,
+				C28B7C892A724BC60009BECE /* LofiFailedView.swift in Sources */,
 				7EE702032A6E4C7E00DEEFA6 /* TimePickerStore.swift in Sources */,
 				7EE7022A2A6E4C7E00DEEFA6 /* DETimePicker.swift in Sources */,
 				7EE701FA2A6E4C7E00DEEFA6 /* EggAnimationStore.swift in Sources */,

--- a/DreamEgg/DreamEgg/Views/Lofi/LofiAwakeView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiAwakeView.swift
@@ -163,7 +163,7 @@ struct LofiAwakeView: View {
                     Spacer()
 
                     NavigationLink {
-                        Text("실패")
+                        LofiFailedView()
 //                      Text("To Fail screen")
                     } label: {
                         Text("아직도 잠을 못잤어요.")

--- a/DreamEgg/DreamEgg/Views/Lofi/LofiFailedView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiFailedView.swift
@@ -62,7 +62,7 @@ struct LofiFailedView: View {
                         Spacer()
                             .frame(maxHeight:50)
                         NavigationLink {
-                            LofiMainEggView()
+                            LofiMainTabView()
                         } label: {
                             Text("내일 꼭 올게요.")
                                 .frame(maxWidth: .infinity)

--- a/DreamEgg/DreamEgg/Views/Lofi/LofiFailedView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiFailedView.swift
@@ -1,0 +1,111 @@
+//
+//  LofiFailedView.swift
+//  DreamEgg
+//
+//  Created by SUNGIL-POS on 2023/07/27.
+//
+
+import SwiftUI
+
+struct LofiFailedView: View {
+    @frozen enum DreamPetFailedSteps {
+        case start
+        case end
+    }
+    @State private var dreamPetFailedSteps: DreamPetFailedSteps = .start
+    @State var dreamCreatureImage : String = "FerretEgg" // TODO: 현재 임의의 데이터를 넣어두었습니다.
+    @State var isButtonsAppear = false
+    @State var isEggDisappear = false
+    
+    var body: some View {
+        ZStack {
+            GradientBackgroundView()
+            
+            VStack(spacing: 96) {
+                switchHeaderTextByStep()
+                    .font(.dosIyagiBold(.title))
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(10)
+
+                Image(dreamCreatureImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: 301, maxHeight: 301)
+                    .opacity(isEggDisappear ? 0 : 1)
+                    .background(
+                        Image("EggPillow")
+                            .resizable()
+                            .frame(width: 246, height: 246)
+                            .offset(y:158)
+                    )
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            withAnimation() {
+                                dreamPetFailedSteps = .end
+                            }
+                            withAnimation() {
+                                isButtonsAppear = true
+                            }
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                            withAnimation(.easeOut(duration: 4.0)) {
+                                isEggDisappear = true
+                            }
+                        }
+                    }
+                
+                if dreamPetFailedSteps == .end {
+                    VStack {
+                        Text("꼭 오래 품어주세요!")
+                            .font(.dosIyagiBold(.body))
+                            .opacity(0.5)
+                        Spacer()
+                            .frame(maxHeight:50)
+                        NavigationLink {
+                            LofiMainEggView()
+                        } label: {
+                            Text("내일 꼭 올게요.")
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 16)
+                                .foregroundColor(.primaryButtonBrown)
+                                .font(.dosIyagiBold(.body))
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.primaryButtonBrown, lineWidth: 5)
+                                }
+                        }
+                        .background { Color.primaryButtonYellow }
+                        .cornerRadius(8)
+                        .padding(.horizontal)
+                    }
+                }
+                else {
+                    Spacer()
+                        .frame(maxHeight: 120)
+                        .opacity(0)
+                }
+            }
+            .padding(.top, 88)
+            .frame(maxHeight: .infinity)
+        }
+        .navigationBarBackButtonHidden()
+    }
+    
+    
+    /// DreamPetBirthView의 라벨링을 순서에 맞게 변경하는 함수입니다.
+    /// - Returns: 순서에 맞는 내용의 Text()를 return 합니다.
+    private func switchHeaderTextByStep() -> some View {
+        switch dreamPetFailedSteps {
+        case .start:
+            return Text("충분히 품지 못해서\n알이 성장을 멈췄어요...")
+        case .end:
+            return Text("잠들기 힘든 밤이죠?\n다음에 다시 도전해봐요.")
+        }
+    }
+}
+
+struct LofiFailedView_Previews: PreviewProvider {
+    static var previews: some View {
+        LofiFailedView()
+    }
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
- 실패 화면에 대한 UT용 작업(#75)을 하려다보니 애초에 실패 화면 자체가 `dev`에 존재하지 않아, 알 품기 실패 시의 화면을 구현했습니다.
- 작업 이슈: #76 

## 작업 사항
- 기 작업 된 `LofiBirthView`를 참고하여 작업.
- 작업 후 @eratchacha에게 검수 받았음.

## `Logic1`
진입과 동시에 화면이 변경됩니다.
```swift
Image(dreamCreatureImage)
    .resizable()
    .aspectRatio(contentMode: .fit)
    .frame(maxWidth: 301, maxHeight: 301)
    .opacity(isEggDisappear ? 0 : 1)
    .background(
        Image("EggPillow")
            .resizable()
            .frame(width: 246, height: 246)
            .offset(y:158)
    )
    .onAppear {
        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
            withAnimation() {
                dreamPetFailedSteps = .end
            }
            withAnimation() {
                isButtonsAppear = true
            }
        }
        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
            withAnimation(.easeOut(duration: 4.0)) {
                isEggDisappear = true
            }
        }
    }
```

 ## 작업 결과
<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-G5T15-DreamEgg/assets/91787174/bae4309e-809e-48d6-9fd2-c9b315f40864" width="30%">
