### PR TITLE
Feat/#86 add lofisleepguideview gesture labeling

### DIFF
--- a/DreamEgg/DreamEgg/Stores/EggAnimationStore.swift
+++ b/DreamEgg/DreamEgg/Stores/EggAnimationStore.swift
@@ -13,6 +13,7 @@ class EggAnimation: ObservableObject {
     @Published private var dragOffset: CGSize = .zero
     @Published private var isLongPress = false
     @Published private var isAnimationRunning = false
+    @Published var amplitude: CGFloat = 0.0
     
     func dragGesture() -> some Gesture {
         DragGesture()
@@ -22,7 +23,7 @@ class EggAnimation: ObservableObject {
                     self.eggHeartBeat()
                 }
                 let dragAngle = Angle(radians: Double(value.translation.width) * 0.01)
-                let newRotationAngle = Angle.degrees(10.0) + dragAngle
+                let newRotationAngle = Angle.degrees(self.amplitude) + dragAngle
                 self.rotationAngle = self.clampRotationAngle(newRotationAngle)
             }
             .onEnded { value in
@@ -51,12 +52,12 @@ class EggAnimation: ObservableObject {
     }
     
     func startPendulumAnimation() {
-        self.rotationAngle = .degrees(10.0 * self.direction)
+        self.rotationAngle = .degrees(amplitude * self.direction)
         self.isAnimationRunning = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.direction = self.rotationAngle.degrees >= 0 ? -1 : 1
             if !self.isLongPress && self.isAnimationRunning {
-                self.rotationAngle = .degrees(10.0 * self.direction)
+                self.rotationAngle = .degrees(self.amplitude * self.direction)
                 self.startPendulumAnimation()
             } else {
                 self.isAnimationRunning = false

--- a/DreamEgg/DreamEgg/Views/Lofi/LofiEggInteractionView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiEggInteractionView.swift
@@ -46,6 +46,7 @@ struct LofiEggInteractionView: View {
                         })
                         .animation(Animation.easeInOut(duration: 1.0), value: eggAnimation.rotationAngle)
                         .onAppear {
+                            eggAnimation.amplitude = 10.0
                             eggAnimation.startPendulumAnimation()
                         }
                 }
@@ -53,8 +54,8 @@ struct LofiEggInteractionView: View {
                     Text("알을 톡 치면 대화가 진행되어요.")
                         .font(.dosIyagiBold(.callout))
                         .foregroundColor(.white)
-                        .opacity(isShowInfo ? 1.0 : 0)
-                        .opacity(isRunInfoAnimation ? 1.0 : 0.3)
+                        .opacity(isShowInfo ? 0.8 : 0)
+                        .opacity(isRunInfoAnimation ? 0.8 : 0.3)
                 NavigationLink(destination: LofiSleepGuideView( isSkippedFromInteractionView:$isSkip).navigationBarBackButtonHidden(true)) {
                     Text("잠드는데 도움이 필요해요.")
                         .frame(maxWidth: .infinity)

--- a/DreamEgg/DreamEgg/Views/Lofi/LofiSleepGuideView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiSleepGuideView.swift
@@ -57,9 +57,10 @@ struct LofiSleepGuideView: View {
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 300, height: 300)
                             .rotationEffect(eggAnimation.rotationAngle, anchor: .bottom)
+                            .gesture(eggAnimation.dragGesture())
                             .animation(Animation.easeInOut(duration: 1.0), value: eggAnimation.rotationAngle)
                             .onAppear {
-                                eggAnimation.reset()
+                                eggAnimation.amplitude = 5.0
                                 eggAnimation.startPendulumAnimation()
                             }
                     }
@@ -162,10 +163,10 @@ struct LofiSleepGuideView: View {
             return Text("먼저,\n심호흡을 해보세요.")
 //            return Text("First, \nTake a deep breath.")
         case .release:
-            return Text("천천히, 그리고 오래동안\n온 몸에 힘을 빼세요.")
+            return Text("이제 알의 태동을 느껴보며\n온 몸에 힘을 빼보아요.")
 //            return Text("Slowly relax your whole body.")
         case .hug:
-            return Text("끝까지 몸을 이완시키는\n느낌에 집중하면서\n오늘의 알을 품어주세요.")
+            return Text("호흡에 집중하면서\n오늘 잠들 준비가 되셨나요?")
 //            return Text("Feel your body relaxing and focus.")
         case .darkening:
             return Text("홀드 버튼을 눌러서\n알이 잘 수 있도록 불을 꺼주세요.")
@@ -184,7 +185,7 @@ struct LofiSleepGuideView: View {
         case .release:
             return Text("...")
         case .hug:
-            return Text("알을 품자")
+            return Text("잘 준비가 된 것 같아요!")
 //            return Text("I'll go to sleep now.")
         case .darkening:
             return Text("베개 밑에 알을 품고\n아침에 살피러 와주세요.")
@@ -216,8 +217,8 @@ struct LofiSleepGuideView: View {
     }
 }
 
-//struct LofiSleepGuideView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        LofiSleepGuideView(isSkippedFromInteractionView:.constant(true))
-//    }
-//}
+struct LofiSleepGuideView_Previews: PreviewProvider {
+    static var previews: some View {
+        LofiSleepGuideView(isSkippedFromInteractionView:.constant(false))
+    }
+}

--- a/DreamEgg/DreamEgg/Views/TestViews/EggInteractionTestView.swift
+++ b/DreamEgg/DreamEgg/Views/TestViews/EggInteractionTestView.swift
@@ -24,6 +24,7 @@ struct EggInteractionTestView: View {
                         .gesture(eggAnimation.dragGesture())
                         .animation(Animation.easeInOut(duration: 1.0), value: eggAnimation.rotationAngle)
                         .onAppear {
+                            eggAnimation.amplitude = 10.0
                             eggAnimation.startPendulumAnimation()
                         }
                     Button("reset") {


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- LofiSleepGuideView의 알 이미지에 제스처 추가
- 수면유도 라벨링 수정

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- EggAnimationStore에서 amplitude를 커스텀 할 수 있도록 수정
- LofiSleepGuideView의 알 이미지에 제스처 추가
- 수면유도 라벨링 수정
- 추후에 버튼 삭제 예정
## `Logic1`
<!-- 작업 내용 1 -->
```swift
class EggAnimation: ObservableObject {
    @Published var rotationAngle: Angle = .degrees(0.0)
    @Published private var direction: CGFloat = 1.0
    @Published private var dragOffset: CGSize = .zero
    @Published private var isLongPress = false
    @Published private var isAnimationRunning = false
    @Published var amplitude: CGFloat = 0.0
    
    func dragGesture() -> some Gesture {
        DragGesture()
            .onChanged { value in
                if !self.isLongPress {
                    self.isLongPress = true
                    self.eggHeartBeat()
                }
                let dragAngle = Angle(radians: Double(value.translation.width) * 0.01)
                let newRotationAngle = Angle.degrees(self.amplitude) + dragAngle
                self.rotationAngle = self.clampRotationAngle(newRotationAngle)
```
`EggAnimation.amplitude = 0.5` 이런 식으로 진폭의 정도를 커스텀할 수 있습니다.
 ## 작업 결과(이미지 첨부는 선택)
