### PR TITLE
[Feat/#105] LofiSleepGuideView 수면 유도활동에서 버튼 삭제하고 자동으로 넘어가는 라벨 애니메이션 구현하기

### DIFF
--- a/DreamEgg/DreamEgg/Views/Lofi/LofiSleepGuideView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiSleepGuideView.swift
@@ -22,6 +22,7 @@ struct LofiSleepGuideView: View {
     
     @State private var sleepGuideSteps: SleepGuideSteps = .start
     @State private var afterHold: Bool = false
+    @State private var labelDelayTime: Double = 2.0
     @StateObject private var eggAnimation = EggAnimation()
     @Binding var isSkippedFromInteractionView: Bool
     
@@ -99,7 +100,7 @@ struct LofiSleepGuideView: View {
                     
                     Spacer()
                     
-                    if sleepGuideSteps != .darkening {
+                    if sleepGuideSteps == .hug {
                         Button {
                             sleepStepSwitcher()
                         } label: {
@@ -118,9 +119,12 @@ struct LofiSleepGuideView: View {
                         .padding(.vertical, 32)
                         .padding(.horizontal)
                     } else if sleepGuideSteps == .darkening {
-                        // - !!!: 상단의 알 Position이 차지할 수 있는 available Space를 제한하기 위한 Spacer
                         Spacer()
-                            .frame(maxHeight: 75)
+                            .frame(maxHeight: 80)
+                    }
+                    else {
+                        Spacer()
+                            .frame(maxHeight: 115)
                     }
                 }
                 
@@ -128,6 +132,8 @@ struct LofiSleepGuideView: View {
                     Button {
                         withAnimation {
                             sleepGuideSteps = .start
+                            labelDelayTime = 2.0
+                            repeatLabelChanging()
                         }
                     } label: {
                         Text("다시 하기")
@@ -147,6 +153,7 @@ struct LofiSleepGuideView: View {
                 if isSkippedFromInteractionView {
                     sleepGuideSteps = .darkening
                 }
+                repeatLabelChanging()
             }
             .onChange(of: scenePhase) { newValue in
                 if isChangingFromInactiveScene(into: newValue) {
@@ -175,7 +182,7 @@ struct LofiSleepGuideView: View {
             return Text("호흡에 집중하면서\n오늘 잠들 준비가 되셨나요?")
 //            return Text("Feel your body relaxing and focus.")
         case .darkening:
-            return Text("홀드 버튼을 눌러서\n알이 잘 수 있도록 불을 꺼주세요.")
+            return Text("잠금 버튼을 눌러서\n알이 잘 수 있도록 불을 꺼주세요.")
 //            return Text("Push the Lock button\nTo incubate the egg.")
         }
     }
@@ -204,14 +211,17 @@ struct LofiSleepGuideView: View {
         case .start:
             withAnimation {
                 sleepGuideSteps = .breath
+                labelDelayTime = 4.0
             }
         case .breath:
             withAnimation {
                 sleepGuideSteps = .release
+                labelDelayTime = 5.0
             }
         case .release:
             withAnimation {
                 sleepGuideSteps = .hug
+                labelDelayTime = 5.0
             }
         case .hug:
             withAnimation {
@@ -220,6 +230,20 @@ struct LofiSleepGuideView: View {
             
         case .darkening:
             print()
+        }
+        repeatLabelChanging()
+    }
+    
+    private func repeatLabelChanging() {
+        
+        switch sleepGuideSteps
+        {
+        case .hug:
+            return
+        default:
+            DispatchQueue.main.asyncAfter(deadline: .now() + labelDelayTime) {
+                sleepStepSwitcher()
+            }
         }
     }
     


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- 작업 이슈: #105 #97 
- LofiSleepGuideView 수면 유도활동에서 버튼 삭제하고 자동으로 넘어가는 라벨 애니메이션 구현하기


## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
1. 버튼 삭제 및 자동으로 라벨이 넘어가는 애니메이션 추가
2. 라벨 넘어가는 시간 변수 추가

## `Logic1`
<!-- 작업 내용 1 -->
### 라벨 자동으로 바꾸는 함수
```swift
private func repeatLabelChanging() {
        switch sleepGuideSteps
        {
        case .hug:
            return
        default:
            DispatchQueue.main.asyncAfter(deadline: .now() + labelDelayTime) {
                sleepStepSwitcher()
            }
        }
    }
```
`sleepStepSwitcher()`에서도 `repeatLabelChanging()`를 호출하게 되면서 반복함.
`.hug`에 도달하면 멈춤.
 ## 작업 결과(이미지 첨부는 선택)
![Simulator Screen Recording - iPhone 14 - 2023-07-29 at 20 47 12](https://github.com/DeveloperAcademy-POSTECH/MC3-G5T15-DreamEgg/assets/102914072/6bf61d3f-73bb-4624-a33c-989b582197c8)

