### PR TITLE
[Feat/#115] Pillow Image 수정

### DIFF
--- a/DreamEgg/DreamEgg/Views/Lofi/LofiEggInteractionView.swift
+++ b/DreamEgg/DreamEgg/Views/Lofi/LofiEggInteractionView.swift
@@ -32,8 +32,10 @@ struct LofiEggInteractionView: View {
                 Spacer()
                     .frame(maxHeight: 65)
                 ZStack {
-                    Image("samplePillow")
-                        .offset(x:0,y:160)
+                    Image("EggPillow")
+                        .resizable()
+                        .frame(width: 246, height: 246)
+                        .offset(y:158)
 
                     Image("\(dailySleepTimeStore.currentDailySleep?.eggName ?? Constant.Errors.NO_EGG)")
                         .resizable()


### PR DESCRIPTION
## 개요 및 관련 이슈
- Pillow Image의 Pixel이 깨지는 현상을 수정합니다.
- 작업 이슈: #115 


## 작업 사항
- `LofiEggInteractionView`의 Pillow Image를 `samplePillow`에서 다른 View와 동일한 `EggPillow`로 교체하였습니다.


## `Logic1`
```swift
...
    Image("EggPillow")
        .resizable()
        .frame(width: 246, height: 246)
        .offset(y:158)
...
```

 ## 작업 결과(이미지 첨부는 선택)
|As-Is|To-Be|
|---|---|
|![image](https://github.com/DeveloperAcademy-POSTECH/MC3-G5T15-DreamEgg/assets/91787174/24493efb-185f-4678-9bde-e6c7544673a4)|![image](https://github.com/DeveloperAcademy-POSTECH/MC3-G5T15-DreamEgg/assets/91787174/11eb7612-796f-44da-9cb1-df8f949eed31)|